### PR TITLE
Fix rider android development.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,6 +121,9 @@ ipch/
 # Visual Studio Trace Files
 *.e2e
 
+# Visual Studio Code Debugger launch file
+.vscode/
+
 # TFS 2012 Local Workspace
 $tf/
 
@@ -396,3 +399,6 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+*.DotSettings.user
+appsettings.Development.json
+.idea/

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <LangVersion>latest</LangVersion>
-		<AvaloniaVersion>11.2.0</AvaloniaVersion>
+        <AvaloniaVersion>11.1.0</AvaloniaVersion>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>

--- a/src/BibleWell.App.Android/BibleWell.App.Android.csproj
+++ b/src/BibleWell.App.Android/BibleWell.App.Android.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net8.0-android</TargetFramework>
@@ -18,7 +18,7 @@
 
     <ItemGroup>
         <PackageReference Include="Avalonia.Android" Version="$(AvaloniaVersion)" />
-        <PackageReference Include="Xamarin.AndroidX.Core.SplashScreen" Version="1.0.1.1" />
+        <PackageReference Include="Xamarin.AndroidX.Core.SplashScreen" Version="1.0.1.13" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/BibleWell.App/BibleWell.App.csproj
+++ b/src/BibleWell.App/BibleWell.App.csproj
@@ -14,7 +14,7 @@
         <PackageReference Include="Avalonia.Fonts.Inter" Version="$(AvaloniaVersion)" />
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
         <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)" />
-        <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+        <PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.2" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
Rider can't launch the Android emulator on Avalonia 11.2.0 for some reason.  Downgrading to 11.1.0 fixes this.