### PR TITLE
Update to .net 9 and update NuGet packages.

### DIFF
--- a/src/BibleWell.App.Android/BibleWell.App.Android.csproj
+++ b/src/BibleWell.App.Android/BibleWell.App.Android.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0-android</TargetFramework>
+        <TargetFramework>net9.0-android</TargetFramework>
         <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
         <ApplicationId>com.CompanyName.BibleWell.App</ApplicationId>
         <ApplicationVersion>1</ApplicationVersion>

--- a/src/BibleWell.App.Browser/BibleWell.App.Browser.csproj
+++ b/src/BibleWell.App.Browser/BibleWell.App.Browser.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WebAssembly">
     <PropertyGroup>
-        <TargetFramework>net8.0-browser</TargetFramework>
+        <TargetFramework>net9.0-browser</TargetFramework>
         <OutputType>Exe</OutputType>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>

--- a/src/BibleWell.App.Desktop/BibleWell.App.Desktop.csproj
+++ b/src/BibleWell.App.Desktop/BibleWell.App.Desktop.csproj
@@ -2,8 +2,8 @@
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
         <!--If you are willing to use Windows/MacOS native APIs you will need to create 3 projects.
-    One for Windows with net8.0-windows TFM, one for MacOS with net8.0-macos and one with net8.0 TFM for Linux.-->
-        <TargetFramework>net8.0</TargetFramework>
+            One for Windows with net9.0-windows TFM, one for MacOS with net9.0-macos and one with net9.0 TFM for Linux.-->
+        <TargetFramework>net9.0</TargetFramework>
         <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     </PropertyGroup>
 

--- a/src/BibleWell.App.iOS/BibleWell.App.iOS.csproj
+++ b/src/BibleWell.App.iOS/BibleWell.App.iOS.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0-ios</TargetFramework>
+        <TargetFramework>net9.0-ios</TargetFramework>
         <SupportedOSPlatformVersion>13.0</SupportedOSPlatformVersion>
     </PropertyGroup>
 

--- a/src/BibleWell.App/BibleWell.App.csproj
+++ b/src/BibleWell.App/BibleWell.App.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
     </PropertyGroup>
 
@@ -15,6 +15,6 @@
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
         <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)" />
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.2" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
.net 9 runs fine on Desktop and Android but the Browser (WASM) target isn't working (probably due to [this issue](https://github.com/AvaloniaUI/Avalonia/discussions/17165)).  It's possible that 11.2.0 fixes this but we can't use it (yet) because Rider won't launch the Android app correctly after the update.  We don't need the Browser target (yet) so I'm pushing this up now.