### PR TITLE
Use appsettings.json files and launch profiles.

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -11,6 +11,8 @@ jobs:
         if: ${{ !github.event.pull_request.draft }}
         name: Build and test
         runs-on: windows-latest
+        environment:
+            name: qa-tests
         steps:
 
             - name: Checkout source code
@@ -30,4 +32,8 @@ jobs:
               run: dotnet build --no-incremental --configuration Release /p:WarningsAsErrors=true /warnaserror
 
             - name: Test
-              run: dotnet test --configuration Release --no-build
+              run: |
+                  dotnet test \
+                      --configuration Release \
+                      --no-build \
+                      -e DOTNET_ENVIRONMENT="${{ vars.DOTNET_ENVIRONMENT }}"

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -32,8 +32,4 @@ jobs:
               run: dotnet build --no-incremental --configuration Release /p:WarningsAsErrors=true /warnaserror
 
             - name: Test
-              run: |
-                  dotnet test \
-                      --configuration Release \
-                      --no-build \
-                      -e DOTNET_ENVIRONMENT="${{ vars.DOTNET_ENVIRONMENT }}"
+              run: dotnet test --configuration Release --no-build -e DOTNET_ENVIRONMENT="${{ vars.DOTNET_ENVIRONMENT }}"

--- a/.gitignore
+++ b/.gitignore
@@ -400,5 +400,4 @@ FodyWeavers.xsd
 # JetBrains Rider
 *.sln.iml
 *.DotSettings.user
-appsettings.Development.json
 .idea/

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,8 +19,13 @@
         <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.0" />
         <PackageVersion Include="coverlet.collector" Version="6.0.0" />
         <PackageVersion Include="HotAvalonia" Version="3.0.0" />
-        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />
-        <PackageVersion Include="Microsoft.Maui.Essentials" Version="9.0.50"/>
+        <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.4" />
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.4" />
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.4" />
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.4" />
+        <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.4" />
+        <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.4" />
+        <PackageVersion Include="Microsoft.Maui.Essentials" Version="9.0.50" />
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageVersion Include="Xamarin.AndroidX.Core.SplashScreen" Version="1.0.1.14" />
         <PackageVersion Include="xunit" Version="2.5.3" />

--- a/src/BibleWell.App.Desktop/Properties/launchSettings.json
+++ b/src/BibleWell.App.Desktop/Properties/launchSettings.json
@@ -1,0 +1,28 @@
+{
+  "profiles": {
+    "BibleWell.App.Desktop (Development)": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    },
+    "BibleWell.App.Desktop (Dev)": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Dev"
+      }
+    },
+    "BibleWell.App.Desktop (QA)": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "QA"
+      }
+    },
+    "BibleWell.App.Desktop (Production)": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Production"
+      }
+    }
+  }
+}

--- a/src/BibleWell.App/App.axaml.cs
+++ b/src/BibleWell.App/App.axaml.cs
@@ -66,8 +66,6 @@ public partial class App : Application
     {
         var configurationBuilder = new ConfigurationBuilder();
 
-        // The environment must be explicitly set as it will not default to "Development".
-        // On the build server this environment variable should be explicitly populated.
         var environment = Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT") ?? "Production";
 
         using var globalConfigurationSettingsFileStream = GetAppSettingsFileStream("appsettings.json");

--- a/src/BibleWell.App/App.axaml.cs
+++ b/src/BibleWell.App/App.axaml.cs
@@ -1,8 +1,9 @@
+using System.Reflection;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
-using Avalonia.Controls.Templates;
 using Avalonia.Data.Core.Plugins;
 using Avalonia.Markup.Xaml;
+using BibleWell.App.Configuration;
 using BibleWell.App.ViewModels;
 using BibleWell.App.ViewModels.Pages;
 using BibleWell.App.Views;
@@ -12,6 +13,7 @@ using BibleWell.Aquifer.Api;
 using BibleWell.Aquifer.Data;
 using CommunityToolkit.Extensions.DependencyInjection;
 using CommunityToolkit.Mvvm.DependencyInjection;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace BibleWell.App;
@@ -25,7 +27,11 @@ public partial class App : Application
 
     public override void OnFrameworkInitializationCompleted()
     {
-        Ioc.Default.ConfigureServices(ConfigureServiceProvider());
+        var config = ConfigureConfiguration();
+
+        var serviceProvider = ConfigureServiceProvider(config);
+        Ioc.Default.ConfigureServices(serviceProvider);
+
         var viewLocator = ConfigureViewLocator();
         DataTemplates.Add(viewLocator);
 
@@ -56,9 +62,35 @@ public partial class App : Application
         base.OnFrameworkInitializationCompleted();
     }
 
-    private static ServiceProvider ConfigureServiceProvider()
+    private static IConfiguration ConfigureConfiguration()
+    {
+        var configurationBuilder = new ConfigurationBuilder();
+
+        // The environment must be explicitly set as it will not default to "Development".
+        // On the build server this environment variable should be explicitly populated.
+        var environment = Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT") ?? "Production";
+
+        using var globalConfigurationSettingsFileStream = GetAppSettingsFileStream("appsettings.json");
+        configurationBuilder.AddJsonStream(globalConfigurationSettingsFileStream);
+
+        using var environmentConfigurationSettingsFileStream = GetAppSettingsFileStream($"appsettings.{environment}.json");
+        configurationBuilder.AddJsonStream(environmentConfigurationSettingsFileStream);
+
+        return configurationBuilder.Build();
+
+        static Stream GetAppSettingsFileStream(string appSettingsFileName)
+        {
+            var appSettingsEmbeddedResourceFileName = $"{Assembly.GetExecutingAssembly().GetName().Name}.{appSettingsFileName}";
+            var configurationStream = Assembly.GetExecutingAssembly().GetManifestResourceStream(appSettingsEmbeddedResourceFileName);
+            return configurationStream ?? throw new InvalidOperationException($"The embedded resource \"{appSettingsEmbeddedResourceFileName}\" was not found.");
+        }
+    }
+
+    private static ServiceProvider ConfigureServiceProvider(IConfiguration configuration)
     {
         var services = new ServiceCollection();
+
+        services.AddOptions<ConfigurationOptions>().Bind(configuration);
 
         ConfigureServices(services);
         ConfigureViewModels(services);

--- a/src/BibleWell.App/BibleWell.App.csproj
+++ b/src/BibleWell.App/BibleWell.App.csproj
@@ -7,14 +7,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <AvaloniaResource Include="Assets\**" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <AvaloniaXaml Remove="Assets\Icons.axaml" />
-    </ItemGroup>
-
-    <ItemGroup>
         <PackageReference Include="Avalonia" />
         <PackageReference Include="Avalonia.Markup.Xaml.Loader" PrivateAssets="All" />
         <PackageReference Include="Avalonia.Themes.Fluent" />
@@ -24,7 +16,9 @@
         <PackageReference Include="CommunityToolkit.Labs.Extensions.DependencyInjection" />
         <PackageReference Include="CommunityToolkit.Mvvm" />
         <PackageReference Include="HotAvalonia" PrivateAssets="All" Publish="True" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
         <PackageReference Include="Microsoft.Maui.Essentials" />
     </ItemGroup>
 
@@ -35,8 +29,24 @@
     </ItemGroup>
 
     <ItemGroup>
+        <None Remove="appsettings.json" />
+        <EmbeddedResource Include="appsettings.json" />
+        <None Remove="appsettings.Development.json" />
+        <EmbeddedResource Include="appsettings.Development.json" />
+        <None Remove="appsettings.Dev.json" />
+        <EmbeddedResource Include="appsettings.Dev.json" />
+        <None Remove="appsettings.QA.json" />
+        <EmbeddedResource Include="appsettings.QA.json" />
+        <None Remove="appsettings.Production.json" />
+        <EmbeddedResource Include="appsettings.Production.json" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <AvaloniaResource Include="Assets\**" />
+        <AvaloniaXaml Remove="Assets\Icons.axaml" />
         <AvaloniaResource Update="Assets\Icons.axaml">
             <SubType>Designer</SubType>
         </AvaloniaResource>
     </ItemGroup>
+
 </Project>

--- a/src/BibleWell.App/Configuration/ConfigurationOptions.cs
+++ b/src/BibleWell.App/Configuration/ConfigurationOptions.cs
@@ -1,0 +1,7 @@
+﻿namespace BibleWell.App.Configuration;
+
+public sealed class ConfigurationOptions
+{
+    public required string AquiferApiBaseUri { get; init; }
+    public required string AquiferApiKey { get; init; }
+}

--- a/src/BibleWell.App/appsettings.Dev.json
+++ b/src/BibleWell.App/appsettings.Dev.json
@@ -1,0 +1,5 @@
+// IMPORTANT: Do not put anything sensitive in this file!
+{
+    "AquiferApiBaseUri": "https://dev.api-bn.aquifer.bible/",
+    "AquiferApiKey": "8b55d5dbb4dd4cd5a7d1e85d6d6d738b"
+}

--- a/src/BibleWell.App/appsettings.Development.json
+++ b/src/BibleWell.App/appsettings.Development.json
@@ -1,0 +1,5 @@
+// IMPORTANT: Do not put anything sensitive in this file!
+{
+    "AquiferApiBaseUri": "http://localhost:5257/",
+    "AquiferApiKey": "8b55d5dbb4dd4cd5a7d1e85d6d6d738b"
+}

--- a/src/BibleWell.App/appsettings.Production.json
+++ b/src/BibleWell.App/appsettings.Production.json
@@ -1,0 +1,5 @@
+// IMPORTANT: Do not put anything sensitive in this file!
+{
+    "AquiferApiBaseUri": "https://api-bn.aquifer.bible/",
+    "AquiferApiKey": "983741eb09ad4ad78b6eee25dfb8a83c"
+}

--- a/src/BibleWell.App/appsettings.QA.json
+++ b/src/BibleWell.App/appsettings.QA.json
@@ -1,0 +1,5 @@
+// IMPORTANT: Do not put anything sensitive in this file!
+{
+    "AquiferApiBaseUri": "https://qa.api-bn.aquifer.bible/",
+    "AquiferApiKey": "40b4a5ece73b4d1b9af26a42ffcbc892"
+}

--- a/src/BibleWell.App/appsettings.example.json
+++ b/src/BibleWell.App/appsettings.example.json
@@ -1,0 +1,4 @@
+{
+    "AquiferApiBaseUri": "Base URL of the Aquifer Internal API.",
+    "AquiferApiKey": "API Key for the Aquifer Internal API."
+}

--- a/src/BibleWell.App/appsettings.json
+++ b/src/BibleWell.App/appsettings.json
@@ -1,0 +1,5 @@
+// IMPORTANT: Do not put anything sensitive in this file!
+{
+    "AquiferApiBaseUri": "",
+    "AquiferApiKey": ""
+}


### PR DESCRIPTION
Implementation details and decisions:
1. All environments have settings files checked in to the repo similar to the [well-web repo config](https://github.com/BiblioNexusStudio/well-web/tree/master/config).
2. All environment settings files are included in the shipped app (we could limit this in the future by passing a build flag for the production build to exclude other config, but see below for reasons not to do this).
3. The appsettings files must be embedded resources in the assembly in order to work on Android (I confirmed this works).
4. The `DOTNET_ENVIRONMENT` environment variable is used in order to determine which environment to use at runtime.
5. A `launchsettings.json` file has been added which adds launch targets for the desktop app (and only the desktop app) so that you can target any environment when launching the app from your IDE (i.e. local Development, Dev, QA, Production).
6. For Android and iOS we'll have to figure out a way to pass settings to the emulator or device in the future (the Android emulator supports launching with environment variables set from Android Studio but I didn't see how to do it from VS or Rider).  For now they will always use Production settings (the default if the environment variable is not set) or we could manually set environment variables in the OS.

Two options to solve 6 in the future:
1. Build admin UI in the app that can change configurations on the fly and reload the app.  The above strategy is compatible with this idea, though it will require reloading the `ConfigurationOptions`.  I like this idea because it makes testing easier.
2. Use multiple build targets and only include the environment files necessary for the build target.  This would mean that a QA build (for testing) and a Production build would have different DLL outputs, though, so I don't like this idea.  Locally you'd also have to rebuild the app with some kind of flag in order to then deploy to the emulator.