### PR TITLE
Get MAUI Essentials somewhat working on Windows.

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
         <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
     </PropertyGroup>
     <PropertyGroup>
-        <AvaloniaVersion>11.2.6</AvaloniaVersion>
+        <AvaloniaVersion>11.2.7</AvaloniaVersion>
     </PropertyGroup>
     <ItemGroup>
         <PackageVersion Include="Avalonia" Version="$(AvaloniaVersion)" />

--- a/nuget.config
+++ b/nuget.config
@@ -4,6 +4,11 @@
         <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
         <add key="Community Toolkit Preview Packages" value="https://pkgs.dev.azure.com/dotnet/CommunityToolkit/_packaging/CommunityToolkit-Labs/nuget/v3/index.json" protocolVersion="3" />
     </packageSources>
+    <auditSources>
+        <!-- Clear to ensure audit sources not inherited from other config files -->
+        <clear />
+        <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    </auditSources>
 
     <packageSourceMapping>
         <packageSource key="nuget.org">

--- a/nuget.config
+++ b/nuget.config
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <packageSources>
+        <clear />
         <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
         <add key="Community Toolkit Preview Packages" value="https://pkgs.dev.azure.com/dotnet/CommunityToolkit/_packaging/CommunityToolkit-Labs/nuget/v3/index.json" protocolVersion="3" />
     </packageSources>
     <auditSources>
-        <!-- Clear to ensure audit sources not inherited from other config files -->
         <clear />
         <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     </auditSources>

--- a/src/BibleWell.App.Desktop/BibleWell.App.Desktop.csproj
+++ b/src/BibleWell.App.Desktop/BibleWell.App.Desktop.csproj
@@ -2,16 +2,11 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <!--We only use the desktop app for testing so customize per developer OS.-->
-        <TargetFramework Condition="$([MSBuild]::IsOSPlatform('Linux'))">net9.0</TargetFramework>
-        <TargetFramework Condition="$([MSBuild]::IsOSPlatform('OSX'))">net9.0-maccatalyst</TargetFramework>
+        <TargetFramework Condition="!$([MSBuild]::IsOSPlatform('Windows'))">net9.0</TargetFramework>
         <TargetFramework Condition="$([MSBuild]::IsOSPlatform('Windows'))">net9.0-windows10.0.19041.0</TargetFramework>
         <ApplicationManifest>app.manifest</ApplicationManifest>
         <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
         <UseMauiEssentials>true</UseMauiEssentials>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-        <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
     </PropertyGroup>
 
     <PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">

--- a/src/BibleWell.App.Desktop/BibleWell.App.Desktop.csproj
+++ b/src/BibleWell.App.Desktop/BibleWell.App.Desktop.csproj
@@ -13,6 +13,7 @@
         <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
         <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
         <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
+        <NoWarn>$(NoWarn);NETSDK1206</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/BibleWell.App.Desktop/BibleWell.App.Desktop.csproj
+++ b/src/BibleWell.App.Desktop/BibleWell.App.Desktop.csproj
@@ -1,15 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <!--If you are willing to use Windows/MacOS native APIs you will need to create 3 projects.
-            One for Windows with net9.0-windows TFM, one for MacOS with net9.0-macos and one with net9.0 TFM for Linux.-->
-        <TargetFramework>net9.0</TargetFramework>
+        <!--We only use the desktop app for testing so customize per developer OS.-->
+        <TargetFramework Condition="$([MSBuild]::IsOSPlatform('Linux'))">net9.0</TargetFramework>
+        <TargetFramework Condition="$([MSBuild]::IsOSPlatform('OSX'))">net9.0-maccatalyst</TargetFramework>
+        <TargetFramework Condition="$([MSBuild]::IsOSPlatform('Windows'))">net9.0-windows10.0.19041.0</TargetFramework>
+        <ApplicationManifest>app.manifest</ApplicationManifest>
         <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
         <UseMauiEssentials>true</UseMauiEssentials>
     </PropertyGroup>
 
-    <PropertyGroup>
-        <ApplicationManifest>app.manifest</ApplicationManifest>
+    <PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
+        <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">
+        <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
+        <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+        <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/BibleWell.App.Desktop/BibleWell.App.Desktop.csproj
+++ b/src/BibleWell.App.Desktop/BibleWell.App.Desktop.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <OutputType>WinExe</OutputType>
+        <OutputType>Exe</OutputType>
         <!--We only use the desktop app for testing so customize per developer OS.-->
         <TargetFramework Condition="$([MSBuild]::IsOSPlatform('Linux'))">net9.0</TargetFramework>
         <TargetFramework Condition="$([MSBuild]::IsOSPlatform('OSX'))">net9.0-maccatalyst</TargetFramework>

--- a/src/BibleWell.App/ViewModels/Pages/ResourcesPageViewModel.cs
+++ b/src/BibleWell.App/ViewModels/Pages/ResourcesPageViewModel.cs
@@ -1,7 +1,10 @@
 ﻿using BibleWell.Aquifer;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Microsoft.Maui.Media;
+#if ANDROID || IOS
 using Microsoft.Maui.Storage;
+#endif
 
 namespace BibleWell.App.ViewModels.Pages;
 
@@ -16,12 +19,18 @@ public sealed partial class ResourcesPageViewModel(ICachingAquiferService _cachi
     {
         try
         {
+            string? fileName = null;
+#if ANDROID || IOS
             var file = await FilePicker.PickAsync();
-            ResourceContent = file is null
+            fileName = file?.FileName;
+#endif
+            ResourceContent = fileName is null
                 ? (await _cachingAquiferService.GetResourceAsync(42))
                     ?.Content
                     ?? "Resource not found."
-                : $"Found file: \"{file.FileName}\"";
+                : $"Found file: \"{fileName}\"";
+
+            await TextToSpeech.Default.SpeakAsync(ResourceContent);
         }
         catch (Exception e)
         {


### PR DESCRIPTION
Anything in MAUI Essentials that needs a Win UI target is still broken (though https://github.com/AvaloniaUI/AvaloniaMauiHybrid/issues/7 looks to be making some progress on that) but things like text-to-speech work now.

It looks like nobody cares about Mac OS support: https://github.com/AvaloniaUI/AvaloniaMauiHybrid/issues/10

Long-term we should create services with any platform specific code so that it's all in one place.  This was more of a POC.