### PR TITLE
Store preferences in OS settings.

### DIFF
--- a/BibleWell.sln
+++ b/BibleWell.sln
@@ -50,6 +50,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 		.github\workflows\pre-merge.yml = .github\workflows\pre-merge.yml
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BibleWell.Platform.Maui", "src\BibleWell.Platform.Maui\BibleWell.Platform.Maui.csproj", "{233E7A76-E8A7-4404-BB46-7C7ED4E84B32}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -109,6 +111,12 @@ Global
 		{BC5A0DFD-1503-4EB9-9D04-BBBFAE1CE89A}.Release|Any CPU.Build.0 = Release|Any CPU
 		{BC5A0DFD-1503-4EB9-9D04-BBBFAE1CE89A}.Release-Optimized|Any CPU.ActiveCfg = Release|Any CPU
 		{BC5A0DFD-1503-4EB9-9D04-BBBFAE1CE89A}.Release-Optimized|Any CPU.Build.0 = Release|Any CPU
+		{233E7A76-E8A7-4404-BB46-7C7ED4E84B32}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{233E7A76-E8A7-4404-BB46-7C7ED4E84B32}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{233E7A76-E8A7-4404-BB46-7C7ED4E84B32}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{233E7A76-E8A7-4404-BB46-7C7ED4E84B32}.Release|Any CPU.Build.0 = Release|Any CPU
+		{233E7A76-E8A7-4404-BB46-7C7ED4E84B32}.Release-Optimized|Any CPU.ActiveCfg = Release|Any CPU
+		{233E7A76-E8A7-4404-BB46-7C7ED4E84B32}.Release-Optimized|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -124,6 +132,7 @@ Global
 		{BC5A0DFD-1503-4EB9-9D04-BBBFAE1CE89A} = {97DC52D2-AAAC-47AA-9912-701BC7465BF8}
 		{02EA681E-C7D8-13C7-8484-4AC65E1B71E8} = {50E00028-435D-430C-998C-365DC2906EBC}
 		{039EFAFA-389F-4FEC-B995-E7ECC730C2DF} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{233E7A76-E8A7-4404-BB46-7C7ED4E84B32} = {97DC52D2-AAAC-47AA-9912-701BC7465BF8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D34B3E09-1D09-437F-AF13-C71E677DEA6E}

--- a/src/BibleWell.App.Android/AndroidApp.cs
+++ b/src/BibleWell.App.Android/AndroidApp.cs
@@ -1,0 +1,18 @@
+﻿using BibleWell.Platform.Maui;
+using BibleWell.Preferences;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BibleWell.App.Android;
+
+public sealed class AndroidApp : App
+{
+    protected override void ConfigurePlatform(ConfigurationBuilder configurationBuilder)
+    {
+    }
+
+    protected override void RegisterPlatformServices(IServiceCollection services)
+    {
+        services.AddSingleton<IUserPreferencesService, MauiUserPreferencesService>();
+    }
+}

--- a/src/BibleWell.App.Android/BibleWell.App.Android.csproj
+++ b/src/BibleWell.App.Android/BibleWell.App.Android.csproj
@@ -42,5 +42,6 @@
 
     <ItemGroup>
         <ProjectReference Include="..\BibleWell.App\BibleWell.App.csproj" />
+        <ProjectReference Include="..\BibleWell.Platform.Maui\BibleWell.Platform.Maui.csproj" />
     </ItemGroup>
 </Project>

--- a/src/BibleWell.App.Android/MainActivity.cs
+++ b/src/BibleWell.App.Android/MainActivity.cs
@@ -1,7 +1,6 @@
 ﻿using Android.Content.PM;
 using Avalonia;
 using Avalonia.Android;
-using Microsoft.Maui.ApplicationModel;
 
 namespace BibleWell.App.Android;
 
@@ -11,7 +10,7 @@ namespace BibleWell.App.Android;
     Icon = "@drawable/icon",
     MainLauncher = true,
     ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize | ConfigChanges.UiMode)]
-public class MainActivity : AvaloniaMainActivity<App>
+public class MainActivity : AvaloniaMainActivity<AndroidApp>
 {
     protected override AppBuilder CustomizeAppBuilder(AppBuilder builder)
     {
@@ -22,6 +21,6 @@ public class MainActivity : AvaloniaMainActivity<App>
     protected override void OnCreate(Bundle? savedInstanceState)
     {
         base.OnCreate(savedInstanceState);
-        Platform.Init(this, savedInstanceState);
+        Microsoft.Maui.ApplicationModel.Platform.Init(this, savedInstanceState);
     }
 }

--- a/src/BibleWell.App.Desktop/DesktopApp.cs
+++ b/src/BibleWell.App.Desktop/DesktopApp.cs
@@ -1,0 +1,18 @@
+﻿using BibleWell.Preferences;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BibleWell.App.Desktop;
+
+public sealed partial class DesktopApp : App
+{
+    protected override void ConfigurePlatform(ConfigurationBuilder configurationBuilder)
+    {
+    }
+
+    protected override void RegisterPlatformServices(IServiceCollection services)
+    {
+        // For now, desktop won't save user preferences.
+        services.AddSingleton<IUserPreferencesService, FakeUserPreferencesService>();
+    }
+}

--- a/src/BibleWell.App.Desktop/Program.cs
+++ b/src/BibleWell.App.Desktop/Program.cs
@@ -17,7 +17,7 @@ internal sealed class Program
     // Avalonia configuration, don't remove; also used by visual designer.
     public static AppBuilder BuildAvaloniaApp()
     {
-        return AppBuilder.Configure<App>()
+        return AppBuilder.Configure<DesktopApp>()
             .UsePlatformDetect()
             .WithInterFont()
             .LogToTrace();

--- a/src/BibleWell.App.iOS/AppDelegate.cs
+++ b/src/BibleWell.App.iOS/AppDelegate.cs
@@ -8,7 +8,7 @@ namespace BibleWell.App.iOS;
 // application events from iOS.
 [Register("AppDelegate")]
 #pragma warning disable CA1711 // Identifiers should not have incorrect suffix
-public partial class AppDelegate : AvaloniaAppDelegate<App>
+public partial class AppDelegate : AvaloniaAppDelegate<iOSApp>
 #pragma warning restore CA1711 // Identifiers should not have incorrect suffix
 {
     protected override AppBuilder CustomizeAppBuilder(AppBuilder builder)

--- a/src/BibleWell.App.iOS/BibleWell.App.iOS.csproj
+++ b/src/BibleWell.App.iOS/BibleWell.App.iOS.csproj
@@ -27,5 +27,6 @@
 
     <ItemGroup>
         <ProjectReference Include="..\BibleWell.App\BibleWell.App.csproj" />
+        <ProjectReference Include="..\BibleWell.Platform.Maui\BibleWell.Platform.Maui.csproj" />
     </ItemGroup>
 </Project>

--- a/src/BibleWell.App.iOS/iOSApp.cs
+++ b/src/BibleWell.App.iOS/iOSApp.cs
@@ -1,0 +1,21 @@
+﻿using BibleWell.Platform.Maui;
+using BibleWell.Preferences;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BibleWell.App.iOS;
+
+#pragma warning disable IDE1006 // Naming Styles: Allow "iOS" prefix
+// ReSharper disable once InconsistentNaming
+public sealed class iOSApp : App
+#pragma warning restore IDE1006 // Naming Styles
+{
+    protected override void ConfigurePlatform(ConfigurationBuilder configurationBuilder)
+    {
+    }
+
+    protected override void RegisterPlatformServices(IServiceCollection services)
+    {
+        services.AddSingleton<IUserPreferencesService, MauiUserPreferencesService>();
+    }
+}

--- a/src/BibleWell.App/BibleWell.App.csproj
+++ b/src/BibleWell.App/BibleWell.App.csproj
@@ -13,19 +13,18 @@
         <PackageReference Include="Avalonia.Themes.Fluent" />
         <PackageReference Include="Avalonia.Fonts.Inter" />
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics"/>
-        <PackageReference Include="CommunityToolkit.Labs.Extensions.DependencyInjection"/>
-        <PackageReference Include="CommunityToolkit.Mvvm"/>
-        <PackageReference Include="HotAvalonia" PrivateAssets="All" Publish="True"/>
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json"/>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection"/>
-        <PackageReference Include="Microsoft.Extensions.Http"/>
-        <PackageReference Include="Microsoft.Extensions.Http.Polly"/>
-        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions"/>
-        <PackageReference Include="Microsoft.Maui.Essentials"/>
-        <PackageReference Include="Polly.Contrib.WaitAndRetry"/>
-        <PackageReference Include="Polly.Extensions.Http"/>
-        <PackageReference Include="System.Private.Uri"/>
+        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" />
+        <PackageReference Include="CommunityToolkit.Labs.Extensions.DependencyInjection" />
+        <PackageReference Include="CommunityToolkit.Mvvm" />
+        <PackageReference Include="HotAvalonia" PrivateAssets="All" Publish="True" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+        <PackageReference Include="Microsoft.Extensions.Http" />
+        <PackageReference Include="Microsoft.Extensions.Http.Polly" />
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
+        <PackageReference Include="Polly.Contrib.WaitAndRetry" />
+        <PackageReference Include="Polly.Extensions.Http" />
+        <PackageReference Include="System.Private.Uri" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/BibleWell.App/ViewLocator.cs
+++ b/src/BibleWell.App/ViewLocator.cs
@@ -16,8 +16,17 @@ public sealed class ViewLocator : IDataTemplate
             return new TextBlock { Text = "Error: No ViewModel provided." };
         }
 
-        return _locator.GetValueOrDefault(data.GetType())?.Invoke()
-            ?? new TextBlock { Text = $"Error: ViewModel \"{data.GetType().Name}\" not registered." };
+        var viewModelType = data.GetType();
+
+        // If this is design-time then the view model we received might be a "Design*" view model and the base
+        // view model is the one actually registered.
+        if (Design.IsDesignMode && viewModelType.BaseType != null && viewModelType.Name.StartsWith("Design"))
+        {
+            viewModelType = viewModelType.BaseType;
+        }
+
+        return _locator.GetValueOrDefault(viewModelType)?.Invoke()
+            ?? new TextBlock { Text = $"Error: ViewModel \"{viewModelType.Name}\" not registered." };
     }
 
     public bool Match(object? data)

--- a/src/BibleWell.App/ViewModels/MainViewModel.cs
+++ b/src/BibleWell.App/ViewModels/MainViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.ObjectModel;
+using System.Reflection;
 using Avalonia.Controls;
 using BibleWell.App.ViewModels.Pages;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -7,7 +8,7 @@ using CommunityToolkit.Mvvm.Input;
 
 namespace BibleWell.App.ViewModels;
 
-public sealed partial class MainViewModel : ViewModelBase
+public partial class MainViewModel : ViewModelBase
 {
     public MainViewModel()
     {
@@ -15,8 +16,9 @@ public sealed partial class MainViewModel : ViewModelBase
         //CurrentPage = GetPageViewModelFromMenuItemTemplate(MenuItems[0]);
     }
 
+    // TODO figure out how to load this in the constructor
     [ObservableProperty]
-    private ViewModelBase _currentPage = new HomePageViewModel(); // TODO figure out how to load this in the constructor
+    private ViewModelBase _currentPage = GetPageViewModelFromMenuItemTemplate(MenuItems[0]);
 
     [ObservableProperty]
     private bool _isMenuPaneOpen = false;
@@ -24,7 +26,7 @@ public sealed partial class MainViewModel : ViewModelBase
     [ObservableProperty]
     private MenuItemTemplate? _selectedMenuItem;
 
-    public ObservableCollection<MenuItemTemplate> MenuItems { get; } =
+    public static ObservableCollection<MenuItemTemplate> MenuItems { get; } =
     [
         new(typeof(HomePageViewModel), "HomeRegular"),
         new(typeof(BiblePageViewModel), "BookOpenRegular"),
@@ -46,9 +48,25 @@ public sealed partial class MainViewModel : ViewModelBase
 
     private static PageViewModelBase GetPageViewModelFromMenuItemTemplate(MenuItemTemplate value)
     {
-        var viewModel = Design.IsDesignMode
-            ? Activator.CreateInstance(value.ViewModelType)
-            : Ioc.Default.GetService(value.ViewModelType);
+        object? viewModel;
+        if (Design.IsDesignMode)
+        {
+            // look for a design-time view model in the same assembly
+            var designTimeViewModelType = Assembly
+                    .GetAssembly(value.ViewModelType)
+                    ?.GetTypes()
+                    .FirstOrDefault(t =>
+                        t != value.ViewModelType &&
+                        value.ViewModelType.IsAssignableFrom(t) &&
+                        t.Name.StartsWith("Design"))
+                ?? value.ViewModelType;
+
+            viewModel = Activator.CreateInstance(designTimeViewModelType);
+        }
+        else
+        {
+            viewModel = Ioc.Default.GetService(value.ViewModelType);
+        }
 
         return viewModel as PageViewModelBase
             ?? throw new InvalidOperationException(

--- a/src/BibleWell.App/ViewModels/Pages/BiblePageViewModel.cs
+++ b/src/BibleWell.App/ViewModels/Pages/BiblePageViewModel.cs
@@ -1,5 +1,8 @@
 ﻿namespace BibleWell.App.ViewModels.Pages;
 
-public sealed partial class BiblePageViewModel : PageViewModelBase
+/// <summary>
+/// ViewModel for use with the <see cref="Views.Pages.BiblePageView"/>.
+/// </summary>
+public partial class BiblePageViewModel : PageViewModelBase
 {
 }

--- a/src/BibleWell.App/ViewModels/Pages/DevPageViewModel.cs
+++ b/src/BibleWell.App/ViewModels/Pages/DevPageViewModel.cs
@@ -1,46 +1,8 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
-using CommunityToolkit.Mvvm.Input;
-using Microsoft.Maui.Media;
-using Microsoft.Maui.Storage;
+﻿namespace BibleWell.App.ViewModels.Pages;
 
-namespace BibleWell.App.ViewModels.Pages;
-
-public sealed partial class DevPageViewModel : PageViewModelBase
+/// <summary>
+/// ViewModel for use with the <see cref="Views.Pages.DevPageView"/>.
+/// </summary>
+public partial class DevPageViewModel : PageViewModelBase
 {
-    [ObservableProperty]
-    private string _fileName = "Click button to show file picker...";
-
-    [RelayCommand]
-    public async Task PickFileAsync()
-    {
-        try
-        {
-            var file = OperatingSystem.IsAndroid() || OperatingSystem.IsIOS()
-                ? await FilePicker.PickAsync()
-                : null;
-
-            FileName = file is null
-                ? "No file selected."
-                : $"Found file: \"{file.FileName}\"";
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine(ex);
-            throw;
-        }
-    }
-
-    [RelayCommand]
-    public async Task SpeakFileNameAsync()
-    {
-        try
-        {
-            await TextToSpeech.Default.SpeakAsync(FileName);
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine(ex);
-            throw;
-        }
-    }
 }

--- a/src/BibleWell.App/ViewModels/Pages/GuidePageViewModel.cs
+++ b/src/BibleWell.App/ViewModels/Pages/GuidePageViewModel.cs
@@ -1,5 +1,8 @@
 ﻿namespace BibleWell.App.ViewModels.Pages;
 
-public sealed partial class GuidePageViewModel : PageViewModelBase
+/// <summary>
+/// ViewModel for use with the <see cref="Views.Pages.GuidePageView"/>.
+/// </summary>
+public partial class GuidePageViewModel : PageViewModelBase
 {
 }

--- a/src/BibleWell.App/ViewModels/Pages/HomePageViewModel.cs
+++ b/src/BibleWell.App/ViewModels/Pages/HomePageViewModel.cs
@@ -1,16 +1,29 @@
 ﻿using Avalonia;
 using Avalonia.Styling;
+using BibleWell.Preferences;
 using CommunityToolkit.Mvvm.Input;
 
 namespace BibleWell.App.ViewModels.Pages;
 
-public sealed partial class HomePageViewModel : PageViewModelBase
+/// <summary>
+/// Design-time ViewModel for use with the <see cref="Views.Pages.HomePageView"/>.
+/// </summary>
+public sealed class DesignHomePageViewModel() : HomePageViewModel(new FakeUserPreferencesService());
+
+/// <summary>
+/// ViewModel for use with the <see cref="Views.Pages.HomePageView"/>.
+/// </summary>
+public partial class HomePageViewModel(IUserPreferencesService _userPreferencesService) : PageViewModelBase
 {
     [RelayCommand]
     public void ChangeTheme()
     {
-        Application.Current!.RequestedThemeVariant = Application.Current!.ActualThemeVariant == ThemeVariant.Dark
+        var newThemeVariant = Application.Current!.ActualThemeVariant == ThemeVariant.Dark
             ? ThemeVariant.Light
             : ThemeVariant.Dark;
+
+        Application.Current!.RequestedThemeVariant = newThemeVariant;
+
+        _userPreferencesService.Set(PreferenceKeys.ThemeVariant, newThemeVariant.ToString());
     }
 }

--- a/src/BibleWell.App/ViewModels/Pages/LibraryPageViewModel.cs
+++ b/src/BibleWell.App/ViewModels/Pages/LibraryPageViewModel.cs
@@ -1,5 +1,8 @@
 ﻿namespace BibleWell.App.ViewModels.Pages;
 
-public sealed partial class LibraryPageViewModel : PageViewModelBase
+/// <summary>
+/// ViewModel for use with the <see cref="Views.Pages.LibraryPageView"/>.
+/// </summary>
+public partial class LibraryPageViewModel : PageViewModelBase
 {
 }

--- a/src/BibleWell.App/ViewModels/Pages/ResourcesPageViewModel.cs
+++ b/src/BibleWell.App/ViewModels/Pages/ResourcesPageViewModel.cs
@@ -4,7 +4,15 @@ using CommunityToolkit.Mvvm.Input;
 
 namespace BibleWell.App.ViewModels.Pages;
 
-public sealed partial class ResourcesPageViewModel(ICachingAquiferService _cachingAquiferService)
+/// <summary>
+/// Design-time ViewModel for use with the <see cref="Views.Pages.ResourcesPageView"/>.
+/// </summary>
+public sealed class DesignResourcesPageViewModel() : ResourcesPageViewModel(new FakeCachingAquiferService());
+
+/// <summary>
+/// ViewModel for use with the <see cref="Views.Pages.ResourcesPageView"/>.
+/// </summary>
+public partial class ResourcesPageViewModel(ICachingAquiferService _cachingAquiferService)
     : PageViewModelBase
 {
     [ObservableProperty]

--- a/src/BibleWell.App/Views/Pages/DevPageView.axaml
+++ b/src/BibleWell.App/Views/Pages/DevPageView.axaml
@@ -12,17 +12,6 @@
 
     <StackPanel>
         <TextBlock Classes="h2">Dev Page</TextBlock>
-        <TextBlock
-            Margin="0 0 0 10"
-            Text="{Binding FileName}" />
-        <StackPanel Orientation="Horizontal" Spacing="5">
-            <Button Command="{Binding PickFileAsync}">
-                Pick File
-            </Button>
-            <Button Command="{Binding SpeakFileNameAsync}">
-                Perform text-to-speech
-            </Button>
-        </StackPanel>
     </StackPanel>
 
 </UserControl>

--- a/src/BibleWell.App/Views/Pages/HomePageView.axaml
+++ b/src/BibleWell.App/Views/Pages/HomePageView.axaml
@@ -10,6 +10,10 @@
     x:Class="BibleWell.App.Views.Pages.HomePageView"
     x:DataType="vm:HomePageViewModel">
 
+    <Design.DataContext>
+        <vm:DesignHomePageViewModel />
+    </Design.DataContext>
+
     <ScrollViewer>
         <StackPanel>
             <TextBlock Classes="h2">Home Page</TextBlock>

--- a/src/BibleWell.App/Views/Pages/ResourcesPageView.axaml
+++ b/src/BibleWell.App/Views/Pages/ResourcesPageView.axaml
@@ -11,6 +11,10 @@
     x:Class="BibleWell.App.Views.Pages.ResourcesPageView"
     x:DataType="vm:ResourcesPageViewModel">
 
+    <Design.DataContext>
+        <vm:DesignResourcesPageViewModel />
+    </Design.DataContext>
+
     <StackPanel>
         <TextBlock Classes="h2">Resources Page</TextBlock>
         <Button Command="{Binding PopulateResourceContentAsync}">

--- a/src/BibleWell.Platform.Maui/BibleWell.Platform.Maui.csproj
+++ b/src/BibleWell.Platform.Maui/BibleWell.Platform.Maui.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <UseMauiEssentials>true</UseMauiEssentials>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Maui.Essentials" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\BibleWell\BibleWell.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/BibleWell.Platform.Maui/MauiUserPreferencesService.cs
+++ b/src/BibleWell.Platform.Maui/MauiUserPreferencesService.cs
@@ -1,0 +1,34 @@
+﻿using BibleWell.Preferences;
+
+namespace BibleWell.Platform.Maui;
+
+/// <summary>
+/// See https://learn.microsoft.com/en-us/dotnet/maui/platform-integration/storage/preferences?view=net-maui-9.0.
+/// </summary>
+public sealed class MauiUserPreferencesService : IUserPreferencesService
+{
+    public bool ContainsKey(string key)
+    {
+        return Microsoft.Maui.Storage.Preferences.Default.ContainsKey(key);
+    }
+
+    public void Remove(string key)
+    {
+        Microsoft.Maui.Storage.Preferences.Default.Remove(key);
+    }
+
+    public void Clear()
+    {
+        Microsoft.Maui.Storage.Preferences.Default.Clear();
+    }
+
+    public void Set<T>(string key, T value)
+    {
+        Microsoft.Maui.Storage.Preferences.Default.Set(key, value);
+    }
+
+    public T Get<T>(string key, T defaultValue)
+    {
+        return Microsoft.Maui.Storage.Preferences.Default.Get(key, defaultValue);
+    }
+}

--- a/src/BibleWell/Aquifer/FakeCachingAquiferService.cs
+++ b/src/BibleWell/Aquifer/FakeCachingAquiferService.cs
@@ -1,0 +1,12 @@
+﻿namespace BibleWell.Aquifer;
+
+/// <summary>
+/// A fake implementation of <see cref="ICachingAquiferService"/> for design-time use.
+/// </summary>
+public sealed class FakeCachingAquiferService : ICachingAquiferService
+{
+    public Task<ResourceContent?> GetResourceContentAsync(int contentId)
+    {
+        return Task.FromResult<ResourceContent?>(null);
+    }
+}

--- a/src/BibleWell/Preferences/FakeUserPreferencesService.cs
+++ b/src/BibleWell/Preferences/FakeUserPreferencesService.cs
@@ -1,0 +1,29 @@
+﻿namespace BibleWell.Preferences;
+
+/// <summary>
+/// A fake implementation of <see cref="IUserPreferencesService"/> for design-time use.
+/// </summary>
+public class FakeUserPreferencesService : IUserPreferencesService
+{
+    public bool ContainsKey(string key)
+    {
+        return false;
+    }
+
+    public void Remove(string key)
+    {
+    }
+
+    public void Clear()
+    {
+    }
+
+    public void Set<T>(string key, T value)
+    {
+    }
+
+    public T Get<T>(string key, T defaultValue)
+    {
+        return defaultValue;
+    }
+}

--- a/src/BibleWell/Preferences/IUserPreferencesService.cs
+++ b/src/BibleWell/Preferences/IUserPreferencesService.cs
@@ -1,0 +1,39 @@
+﻿namespace BibleWell.Preferences;
+
+public interface IUserPreferencesService
+{
+    /// <summary>
+    /// Checks for the existence of a given key.
+    /// </summary>
+    /// <param name="key">The key to check.</param>
+    /// <returns><c>true</c> if the key exists in the preferences, otherwise <c>false</c>.</returns>
+    bool ContainsKey(string key);
+
+    /// <summary>
+    /// Removes a key and its associated value if it exists.
+    /// </summary>
+    /// <param name="key">The key to remove.</param>
+    void Remove(string key);
+
+    /// <summary>
+    /// Clears all keys and values.
+    /// </summary>
+    void Clear();
+
+    /// <summary>
+    /// Sets a value for a given key.
+    /// </summary>
+    /// <typeparam name="T">Type of the object that is stored in this preference.</typeparam>
+    /// <param name="key">The key to set the value for.</param>
+    /// <param name="value">Value to set.</param>
+    void Set<T>(string key, T value);
+
+    /// <summary>
+    /// Gets the value for a given key, or the default specified if the key does not exist.
+    /// </summary>
+    /// <typeparam name="T">The type of the object stored for this preference.</typeparam>
+    /// <param name="key">The key to retrieve the value for.</param>
+    /// <param name="defaultValue">The default value to return when no existing value for <paramref name="key"/> exists.</param>
+    /// <returns>Value for the given key, or the value in <paramref name="defaultValue"/> if it does not exist.</returns>
+    T Get<T>(string key, T defaultValue);
+}

--- a/src/BibleWell/Preferences/PreferenceKeys.cs
+++ b/src/BibleWell/Preferences/PreferenceKeys.cs
@@ -1,0 +1,6 @@
+﻿namespace BibleWell.Preferences;
+
+public static class PreferenceKeys
+{
+    public const string ThemeVariant = nameof(ThemeVariant);
+}


### PR DESCRIPTION
The user's current selected theme variant (light or dark mode) is now persisted across app launches using app user preference storage on Android and iOS.

MAUI Essentials won't work for desktop.  Therefore, I created a pattern of using an interface for platform specific behavior and creating platform specific implementations which are registered in each platform app project (Avalonia suggests this pattern in their docs).  Android and iOS will for the most part share a MAUI Essentials implementation so I created a separate project containing MAUI Essentials.  To achieve this, each platform now has its own Avalonia app that inherits from the base BibleWell.App.App Avalonia app so that we can inject platform specific behavior during initialization.

Adding services for DI into the ViewModel constructors caused the design-time views to break.  I followed Avalonia's suggested patterns to create design-time view models and used those instead.  This required tweaking the view locator with the baked in assumption that all design-time view models will begin with the word `Design` as in `DesignFooViewModel`.  This extra logic with reflection only runs during design-time view creation and won't impact app performance.

Fixing design-time also requires fake service implementations.  That's actually convenient because we can use them for the desktop platform specific implementations as well.

I deleted the dev page content (file picker and text-to-speech POCs) because it was directly invoking MAUI Essentials and doing OS checks which is contrary to the new architectural pattern.