### PR TITLE
Use consistent design view model strategy.

### DIFF
--- a/src/BibleWell.App/ViewModels/MainViewModel.cs
+++ b/src/BibleWell.App/ViewModels/MainViewModel.cs
@@ -8,6 +8,14 @@ using CommunityToolkit.Mvvm.Input;
 
 namespace BibleWell.App.ViewModels;
 
+/// <summary>
+/// Design-time view model for use with the <see cref="Views.MainView"/>.
+/// </summary>
+public sealed class DesignMainViewModel() : MainViewModel();
+
+/// <summary>
+/// View model for use with the <see cref="Views.MainView"/>.
+/// </summary>
 public partial class MainViewModel : ViewModelBase
 {
     public MainViewModel()

--- a/src/BibleWell.App/ViewModels/Pages/BiblePageViewModel.cs
+++ b/src/BibleWell.App/ViewModels/Pages/BiblePageViewModel.cs
@@ -1,7 +1,12 @@
 ﻿namespace BibleWell.App.ViewModels.Pages;
 
 /// <summary>
-/// ViewModel for use with the <see cref="Views.Pages.BiblePageView"/>.
+/// Design-time view model for use with the <see cref="Views.Pages.BiblePageView"/>.
+/// </summary>
+public sealed class DesignBiblePageViewModel() : BiblePageViewModel();
+
+/// <summary>
+/// View model for use with the <see cref="Views.Pages.BiblePageView"/>.
 /// </summary>
 public partial class BiblePageViewModel : PageViewModelBase
 {

--- a/src/BibleWell.App/ViewModels/Pages/DevPageViewModel.cs
+++ b/src/BibleWell.App/ViewModels/Pages/DevPageViewModel.cs
@@ -1,7 +1,12 @@
 ﻿namespace BibleWell.App.ViewModels.Pages;
 
 /// <summary>
-/// ViewModel for use with the <see cref="Views.Pages.DevPageView"/>.
+/// Design-time view model for use with the <see cref="Views.Pages.DevPageView"/>.
+/// </summary>
+public sealed class DesignDevPageViewModel() : DevPageViewModel();
+
+/// <summary>
+/// View model for use with the <see cref="Views.Pages.DevPageView"/>.
 /// </summary>
 public partial class DevPageViewModel : PageViewModelBase
 {

--- a/src/BibleWell.App/ViewModels/Pages/GuidePageViewModel.cs
+++ b/src/BibleWell.App/ViewModels/Pages/GuidePageViewModel.cs
@@ -1,7 +1,12 @@
 ﻿namespace BibleWell.App.ViewModels.Pages;
 
 /// <summary>
-/// ViewModel for use with the <see cref="Views.Pages.GuidePageView"/>.
+/// Design-time view model for use with the <see cref="Views.Pages.GuidePageView"/>.
+/// </summary>
+public sealed class DesignGuidePageViewModel() : GuidePageViewModel();
+
+/// <summary>
+/// View model for use with the <see cref="Views.Pages.GuidePageView"/>.
 /// </summary>
 public partial class GuidePageViewModel : PageViewModelBase
 {

--- a/src/BibleWell.App/ViewModels/Pages/HomePageViewModel.cs
+++ b/src/BibleWell.App/ViewModels/Pages/HomePageViewModel.cs
@@ -6,12 +6,12 @@ using CommunityToolkit.Mvvm.Input;
 namespace BibleWell.App.ViewModels.Pages;
 
 /// <summary>
-/// Design-time ViewModel for use with the <see cref="Views.Pages.HomePageView"/>.
+/// Design-time view model for use with the <see cref="Views.Pages.HomePageView"/>.
 /// </summary>
 public sealed class DesignHomePageViewModel() : HomePageViewModel(new FakeUserPreferencesService());
 
 /// <summary>
-/// ViewModel for use with the <see cref="Views.Pages.HomePageView"/>.
+/// View model for use with the <see cref="Views.Pages.HomePageView"/>.
 /// </summary>
 public partial class HomePageViewModel(IUserPreferencesService _userPreferencesService) : PageViewModelBase
 {

--- a/src/BibleWell.App/ViewModels/Pages/LibraryPageViewModel.cs
+++ b/src/BibleWell.App/ViewModels/Pages/LibraryPageViewModel.cs
@@ -1,7 +1,12 @@
 ﻿namespace BibleWell.App.ViewModels.Pages;
 
 /// <summary>
-/// ViewModel for use with the <see cref="Views.Pages.LibraryPageView"/>.
+/// Design-time view model for use with the <see cref="Views.Pages.LibraryPageView"/>.
+/// </summary>
+public sealed class DesignLibraryPageViewModel() : LibraryPageViewModel();
+
+/// <summary>
+/// View model for use with the <see cref="Views.Pages.LibraryPageView"/>.
 /// </summary>
 public partial class LibraryPageViewModel : PageViewModelBase
 {

--- a/src/BibleWell.App/ViewModels/Pages/PageViewModelBase.cs
+++ b/src/BibleWell.App/ViewModels/Pages/PageViewModelBase.cs
@@ -1,7 +1,7 @@
 ﻿namespace BibleWell.App.ViewModels.Pages;
 
 /// <summary>
-/// All pages should derive from this class.
+/// All page view models should derive from this class.
 /// </summary>
 public abstract class PageViewModelBase : ViewModelBase
 {

--- a/src/BibleWell.App/ViewModels/Pages/ResourcesPageViewModel.cs
+++ b/src/BibleWell.App/ViewModels/Pages/ResourcesPageViewModel.cs
@@ -5,12 +5,12 @@ using CommunityToolkit.Mvvm.Input;
 namespace BibleWell.App.ViewModels.Pages;
 
 /// <summary>
-/// Design-time ViewModel for use with the <see cref="Views.Pages.ResourcesPageView"/>.
+/// Design-time view model for use with the <see cref="Views.Pages.ResourcesPageView"/>.
 /// </summary>
 public sealed class DesignResourcesPageViewModel() : ResourcesPageViewModel(new FakeCachingAquiferService());
 
 /// <summary>
-/// ViewModel for use with the <see cref="Views.Pages.ResourcesPageView"/>.
+/// View model for use with the <see cref="Views.Pages.ResourcesPageView"/>.
 /// </summary>
 public partial class ResourcesPageViewModel(ICachingAquiferService _cachingAquiferService)
     : PageViewModelBase

--- a/src/BibleWell.App/Views/MainView.axaml
+++ b/src/BibleWell.App/Views/MainView.axaml
@@ -12,9 +12,7 @@
     x:DataType="vm:MainViewModel">
 
     <Design.DataContext>
-        <!-- This only sets the DataContext for the previewer in an IDE,
-         to set the actual DataContext for runtime, set the DataContext property in code (look at App.axaml.cs) -->
-        <vm:MainViewModel />
+        <vm:DesignMainViewModel />
     </Design.DataContext>
 
     <SplitView

--- a/src/BibleWell.App/Views/MainWindow.axaml
+++ b/src/BibleWell.App/Views/MainWindow.axaml
@@ -15,6 +15,6 @@
     Height="960">
 
     <!-- The Main Window is only used by Desktop applications so just load in the Main View. -->
-    <views:MainView></views:MainView>
+    <views:MainView />
 
 </Window>

--- a/src/BibleWell.App/Views/Pages/BiblePageView.axaml
+++ b/src/BibleWell.App/Views/Pages/BiblePageView.axaml
@@ -10,6 +10,10 @@
     x:Class="BibleWell.App.Views.Pages.BiblePageView"
     x:DataType="vm:BiblePageViewModel">
 
+    <Design.DataContext>
+        <vm:DesignBiblePageViewModel />
+    </Design.DataContext>
+
     <TextBlock Classes="h2">Bible Page</TextBlock>
 
 </UserControl>

--- a/src/BibleWell.App/Views/Pages/DevPageView.axaml
+++ b/src/BibleWell.App/Views/Pages/DevPageView.axaml
@@ -10,6 +10,10 @@
     x:Class="BibleWell.App.Views.Pages.DevPageView"
     x:DataType="vm:DevPageViewModel">
 
+    <Design.DataContext>
+        <vm:DesignDevPageViewModel />
+    </Design.DataContext>
+
     <StackPanel>
         <TextBlock Classes="h2">Dev Page</TextBlock>
     </StackPanel>

--- a/src/BibleWell.App/Views/Pages/GuidePageView.axaml
+++ b/src/BibleWell.App/Views/Pages/GuidePageView.axaml
@@ -10,6 +10,10 @@
     x:Class="BibleWell.App.Views.Pages.GuidePageView"
     x:DataType="vm:GuidePageViewModel">
 
+    <Design.DataContext>
+        <vm:DesignGuidePageViewModel />
+    </Design.DataContext>
+
     <TextBlock Classes="h2">Guide Page</TextBlock>
 
 </UserControl>

--- a/src/BibleWell.App/Views/Pages/LibraryPageView.axaml
+++ b/src/BibleWell.App/Views/Pages/LibraryPageView.axaml
@@ -10,6 +10,10 @@
     x:Class="BibleWell.App.Views.Pages.LibraryPageView"
     x:DataType="vm:LibraryPageViewModel">
 
+    <Design.DataContext>
+        <vm:DesignLibraryPageViewModel />
+    </Design.DataContext>
+
     <TextBlock Classes="h2">Library Page</TextBlock>
 
 </UserControl>


### PR DESCRIPTION
Always use a design-time view model, even if there is no dependency injection for the standard view model.  This will make all view configuration consistent and has the benefit of allowing arbitrary design-time data to be more easily configured (such as displaying certain text in the designer view).